### PR TITLE
New timer lambdas for DSWx-NI (and possibly other use cases)

### DIFF
--- a/ci/jenkins/build-test-deploy/build.sh
+++ b/ci/jenkins/build-test-deploy/build.sh
@@ -61,3 +61,11 @@ popd
 pushd ${WORKSPACE}/lambdas/batch_process
 python setup.py package --version ${TAG} --workspace workspace --lambda-func batch_process_lambda.py --package-dir ${WORKSPACE}/lambda_packages
 popd
+
+pushd ${WORKSPACE}/lambdas/grq-on-demand
+python setup.py package --version ${TAG} --workspace workspace --lambda-func grq_on_demand_lambda.py --package-dir ${WORKSPACE}/lambda_packages
+popd
+
+pushd ${WORKSPACE}/lambdas/catalog-ingest
+python setup.py package --version ${TAG} --workspace workspace --lambda-func catalog_ingest_lambda.py --package-dir ${WORKSPACE}/lambda_packages
+popd

--- a/lambdas/catalog-ingest/catalog_ingest_lambda.py
+++ b/lambdas/catalog-ingest/catalog_ingest_lambda.py
@@ -50,17 +50,21 @@ def submit_job(
     payload = {
         'queue': job_queue,
         "priority": priority,
-        'tags': tags,
+        'tags': json.dumps([tags]),
         'type': f'job-{job_type}:{job_release}',
         'params': json.dumps(job_params),
         'name': f'catalog-ingest-timer-{job_type}-{datetime.now(timezone.utc).replace(tzinfo=None).strftime(JOB_NAME_DATETIME_FORMAT)}_{minutes}',
-        'enable_dedup': dedup
     }
 
     logger.info(f'Mozart payload: {json.dumps(payload)}')
     logger.info(f'Submitting job to {mozart_url}')
 
-    resp = requests.post(mozart_url, json=payload, headers={'Content-Type': 'application/json'}, verify=False)
+    resp = requests.post(
+        mozart_url,
+        data=payload,
+        params=dict(enable_dedup=dedup),
+        verify=False
+    )
 
     logger.info(f"Request code: {resp.status_code}")
     logger.info(f"Request text: {resp.text}")

--- a/lambdas/catalog-ingest/catalog_ingest_lambda.py
+++ b/lambdas/catalog-ingest/catalog_ingest_lambda.py
@@ -1,0 +1,141 @@
+import argparse
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import dateutil.parser
+import requests
+from dateutil.relativedelta import relativedelta
+
+
+logger = logging.getLogger()
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] [%(name)s::%(lineno)d] %(message)s'
+)
+logger.setLevel(logging.INFO)
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+JOB_NAME_DATETIME_FORMAT = "%Y%m%dT%H%M%S"
+
+
+def submit_job(
+        mozart_host,
+        job_type,
+        job_release,
+        job_queue,
+        priority,
+        tags,
+        query_end_dt: datetime,
+        # use_temporal,
+        minutes,
+        revision_margin,
+        dedup,
+        **extra_params
+):
+    mozart_url = f'https://{mozart_host}/mozart/api/v0.1/job/submit'
+
+    job_params: dict = {}
+
+    query_end_dt = query_end_dt - relativedelta(minutes=revision_margin)
+    query_start_dt = query_end_dt - relativedelta(minutes=minutes)
+
+    # *_PARAM = param name in HySDS IO, *_PARAM_PREFIX useful if param values are CLI parameters (eg. --start-date=)
+    job_params[os.getenv('START_PARAM'), 'start_date'] = f'{os.getenv('START_PARAM_PREFIX', '')}{query_start_dt.strftime(DATETIME_FORMAT)}'
+    job_params[os.getenv('END_PARAM'), 'end_date'] = f'{os.getenv('END_PARAM_PREFIX', '')}{query_end_dt.strftime(DATETIME_FORMAT)}'
+
+    job_params.update(extra_params)
+
+    payload = {
+        'queue': job_queue,
+        "priority": priority,
+        'tags': tags,
+        'type': f'job-{job_type}:{job_release}',
+        'params': json.dumps(job_params),
+        'name': f'catalog-ingest-timer-{job_type}-{datetime.now(timezone.utc).replace(tzinfo=None).strftime(JOB_NAME_DATETIME_FORMAT)}_{minutes}',
+        'enable_dedup': dedup
+    }
+
+    logger.info(f'Mozart payload: {json.dumps(payload)}')
+    logger.info(f'Submitting job to {mozart_url}')
+
+    resp = requests.post(mozart_url, json=payload, headers={'Content-Type': 'application/json'}, verify=False)
+
+    logger.info(f"Request code: {resp.status_code}")
+    logger.info(f"Request text: {resp.text}")
+    resp.raise_for_status()
+
+    result = resp.json()
+
+    if "result" in result.keys() and "success" in result.keys():
+        if result["success"] is True:
+            job_id = result["result"]
+            logger.info(f"submitted job: {job_type} job_id: {job_id}")
+            return job_id
+        else:
+            logger.error(f"job not submitted successfully: {result}")
+            raise Exception(f"job not submitted successfully: {result}")
+    else:
+        raise Exception(f"job not submitted successfully: {result}")
+
+
+def lambda_handler(event, context):
+    logger.info(f"Got event: {json.dumps(event)}")
+
+    mozart_host = os.environ['MOZART_HOST']
+    job_release = os.environ['JOB_RELEASE']
+
+    job_type = event.pop('job_type')
+    job_queue = event.pop('job_queue')
+    priority = event.pop('priority')
+    tags = event.pop('tags')
+    minutes = event.pop('minutes', 60)
+    revision_margin = event.pop('revision_margin', 0)
+    extra_params = event.pop('extra_params', {})
+    dedup = event.pop('enable_dedup', False)
+
+    event_time = event.pop('time')
+
+    submit_job(
+        mozart_host,
+        job_type,
+        job_release,
+        job_queue,
+        priority,
+        tags,
+        dateutil.parser.isoparse(event_time),
+        minutes,
+        revision_margin,
+        dedup,
+        **extra_params
+    )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('mozart_host', help='Mozart host (IP or hostname with optional port)')
+    parser.add_argument('job_type', help='Type of job to submit')
+    parser.add_argument('job_release', help='Job release')
+    parser.add_argument('job_queue', help='Job queue')
+    parser.add_argument('priority', type=int, help='Job priority')
+    parser.add_argument('tags', help='Tags')
+    parser.add_argument('minutes', type=int, help='minutes')
+    parser.add_argument('revision_margin', type=int, help='revision_margin')
+    parser.add_argument('--dedup', action='store_true', help='Enable job dedupe')
+
+    args = parser.parse_args()
+
+    submit_job(
+        args.mozart_host,
+        args.job_type,
+        args.job_release,
+        args.job_queue,
+        args.priority,
+        args.tags,
+        datetime.now(timezone.utc),
+        args.minutes,
+        args.revision_margin,
+        args.dedup,
+    )

--- a/lambdas/catalog-ingest/catalog_ingest_lambda.py
+++ b/lambdas/catalog-ingest/catalog_ingest_lambda.py
@@ -42,8 +42,8 @@ def submit_job(
     query_start_dt = query_end_dt - relativedelta(minutes=minutes)
 
     # *_PARAM = param name in HySDS IO, *_PARAM_PREFIX useful if param values are CLI parameters (eg. --start-date=)
-    job_params[os.getenv('START_PARAM'), 'start_date'] = f'{os.getenv('START_PARAM_PREFIX', '')}{query_start_dt.strftime(DATETIME_FORMAT)}'
-    job_params[os.getenv('END_PARAM'), 'end_date'] = f'{os.getenv('END_PARAM_PREFIX', '')}{query_end_dt.strftime(DATETIME_FORMAT)}'
+    job_params[os.getenv('START_PARAM', 'start_date')] = f'{os.getenv('START_PARAM_PREFIX', '')}{query_start_dt.strftime(DATETIME_FORMAT)}'
+    job_params[os.getenv('END_PARAM', 'end_date')] = f'{os.getenv('END_PARAM_PREFIX', '')}{query_end_dt.strftime(DATETIME_FORMAT)}'
 
     job_params.update(extra_params)
 

--- a/lambdas/catalog-ingest/requirements.txt
+++ b/lambdas/catalog-ingest/requirements.txt
@@ -1,0 +1,6 @@
+aws-lambda-powertools==2.43.1
+requests==2.32.4
+python-dateutil==2.9.0.post0
+
+# urllib3 contains an incompatible change. pinning such that we stay on urllib3 1.x
+urllib3<2

--- a/lambdas/catalog-ingest/setup.py
+++ b/lambdas/catalog-ingest/setup.py
@@ -1,0 +1,207 @@
+"""
+Copyright (c) 2022 Jet Propulsion Laboratory,
+California Institute of Technology.  All rights reserved
+"""
+import glob
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+import setuptools
+import setuptools.command.sdist
+
+WHEELHOUSE = "wheelhouse"
+DIST = "dist"
+
+
+class Package(setuptools.Command):
+    """Package Code and Dependencies into wheelhouse"""
+    description = "Run wheels for dependencies and submodules dependencies"
+
+    ARCHIVE_NAME = "lambda-catalog-ingest-handler"
+
+    user_options = [
+        ('version=', 'v', 'version release'),
+        ('lambda-func=', 'l', 'Path to the Lambda function to softlink to '
+                              'lambda_function.py'),
+        ('workspace=', 'w', 'Workspace directory. '
+                            'Default is current working dir.'),
+        ('package-dir=', 'p', 'Directory where the lambda package will be '
+                              'located.')
+    ]
+
+    def __init__(self, dist):
+        self.dist = dist
+        setuptools.Command.__init__(self, dist)
+
+    def initialize_options(self):
+        self.version = None
+        self.lambda_func = None
+        self.workspace = None
+        self.package_dir = None
+
+    def finalize_options(self):
+        """Post-process options."""
+        if self.version is None:
+            raise Exception("Parameter --version is missing")
+        if self.lambda_func is None:
+            raise Exception("Parameter --lambda-func is missing")
+        if self.workspace is None:
+            self.workspace = os.getcwd()
+        self.workspace = os.path.abspath(self.workspace)
+        if self.package_dir is None:
+            raise Exception("Parameter --package-dir is missing")
+        else:
+            self.package_dir = os.path.abspath(self.package_dir)
+
+    def localize_requirements(self):
+        """
+        After the package is unpacked at the target destination, the
+        requirements can be installed locally from the wheelhouse folder using
+        the option --no-index on pip install which ignores package index
+        (only looking at --find-links URLs instead).
+        --find-links <url | path> looks for archive from url or path.
+        Since the original requirements.txt might have links to a non pip repo
+        such as github (https) it will parse the links for the archive from a
+        url and not from the wheelhouse. This functions creates a new
+        requirements.txt with the only name and version for each of the
+        packages, thus eliminating the need to fetch / parse links from http
+        sources and install all archives from the wheelhouse.
+        """
+        dependencies = open("requirements.txt").read().split("\n")
+        local_dependencies = []
+
+        for dependency in dependencies:
+            if dependency:
+                if "egg=" in dependency:
+                    pkg_name = dependency.split("egg=")[-1]
+                    local_dependencies.append(pkg_name)
+                elif "git+" in dependency:
+                    pkg_name = dependency.split("/")[-1].split(".")[0]
+                    local_dependencies.append(pkg_name)
+                else:
+                    local_dependencies.append(dependency)
+
+        print("local packages in wheel: %s", local_dependencies)
+        self.execute("mv requirements.txt requirements.orig")
+
+        with open("requirements.txt", "w") as requirements_file:
+            # filter is used to remove empty list members (None).
+            requirements_file.write("\n".join(
+                filter(None, local_dependencies)))
+
+    def execute(self, command, cwd=None):
+        """
+        The execute command will loop and keep on reading the stdout and check
+        for the return code and displays the output in real time.
+        """
+
+        print("Running shell command: ", command)
+
+        try:
+            return_code = subprocess.check_call(shlex.split(command),
+                                                stdout=sys.stdout,
+                                                stderr=sys.stderr, cwd=cwd)
+        except subprocess.CalledProcessError as e:
+            return_code = e.returncode
+            raise IOError("Shell commmand `%s` failed with return code %d." % (
+                    command, return_code)) from e
+
+        return return_code
+
+    def run_os_commands(self, commands, cwd=None):
+        for command in commands:
+            self.execute(command, cwd=cwd)
+
+    def restore_requirements_txt(self):
+        if os.path.exists("requirements.orig"):
+            print("Restoring original requirements.txt file")
+            commands = [
+                "rm requirements.txt",
+                "mv requirements.orig requirements.txt"
+            ]
+            self.run_os_commands(commands)
+
+    def __create_softlink(self, lambda_func):
+        """
+        Softlink the lambda to lambda_function.py
+
+        :param lambda_func: The path to the lambda function to softlink
+        :return:
+        """
+        dir = os.path.dirname(lambda_func)
+        aws_lambda_file_path = os.path.join(dir, 'lambda_function.py')
+
+        # Clear out the symbolic link if it exists
+        if os.path.exists(aws_lambda_file_path) or \
+                os.path.islink(aws_lambda_file_path):
+            print("Unlinking existing symbolic link: {}".format(
+                aws_lambda_file_path))
+            os.unlink(aws_lambda_file_path)
+
+        print("Softlinking {} to {}".format(lambda_func,
+                                            aws_lambda_file_path))
+        os.symlink(lambda_func, aws_lambda_file_path)
+
+    def run(self):
+        commands = []
+        commands.extend([
+            "rm -rf {workspace}/{dir}".format(workspace=self.workspace,
+                                              dir=WHEELHOUSE),
+            "rm -rf {workspace}/{dir}".format(workspace=self.workspace,
+                                              dir=DIST),
+            "mkdir -p {workspace}/{dir}".format(workspace=self.workspace,
+                                                dir=WHEELHOUSE),
+            "mkdir -p {workspace}/{dir}".format(workspace=self.workspace,
+                                                dir=DIST),
+            "pip wheel --wheel-dir={workspace}/{dir} "
+            "-r requirements.txt".format(workspace=self.workspace,
+                                         dir=WHEELHOUSE),
+            "unzip \"{workspace}/{dir}/*.whl\" -d {workspace}/{dir}".format(
+                workspace=self.workspace, dir=WHEELHOUSE),
+            "find {workspace}/{dir} -type f -name \"*.whl\" -delete".format(
+                workspace=self.workspace, dir=WHEELHOUSE)
+        ])
+
+        print("Packing requirements.txt into wheelhouse")
+        self.run_os_commands(commands)
+        print("Generating local requirements.txt")
+        self.localize_requirements()
+        self.__create_softlink(self.lambda_func)
+        print("Packing code and wheelhouse into dist")
+        lambda_package = "{}/{}/{}-{}.zip".format(self.workspace, DIST,
+                                                  self.ARCHIVE_NAME,
+                                                  self.version)
+        self.execute(
+            "zip -9 {package_name} {files}".format(
+                package_name=lambda_package,
+                files=' '.join(glob.glob("lambda_function.py"))))
+        os.chdir(os.path.join(self.workspace, WHEELHOUSE))
+        self.execute(
+            "zip -rg ../{dist}/{archive_name}-{version}.zip "
+            "{files}".format(dist=DIST, archive_name=self.ARCHIVE_NAME,
+                             version=self.version,
+                             files=' '.join(glob.glob("**", recursive=True))))
+        print("Copying {} to {}".format(os.path.abspath(lambda_package),
+                                        self.package_dir))
+        if not os.path.exists(self.package_dir):
+            os.mkdir(self.package_dir)
+        shutil.copyfile(os.path.abspath(lambda_package),
+                        os.path.join(self.package_dir,
+                                     os.path.basename(lambda_package)))
+        os.chdir("../..")
+        self.restore_requirements_txt()
+
+
+setuptools.setup(
+    name="lambda-catalog-ingest-handler",
+    author="PCM",
+    description="Lambda package for submitting catalog ingest jobs",
+    packages=setuptools.find_packages(),
+    include_package_data=True,
+    cmdclass={
+        "package": Package
+    },
+)

--- a/lambdas/grq-on-demand/grq_on_demand_lambda.py
+++ b/lambdas/grq-on-demand/grq_on_demand_lambda.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+import logging
+import os
+
+import requests
+
+
+logger = logging.getLogger()
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] [%(name)s::%(lineno)d] %(message)s'
+)
+logger.setLevel(logging.INFO)
+
+
+def grq_on_demand(
+        mozart_host,
+        query,
+        job_type,
+        job_release,
+        job_queue,
+        priority,
+        tags,
+        kwargs,
+        dedup,
+        **payload_kwargs
+):
+    grq_url = f'https://{mozart_host}/grq/api/v0.1/grq/on-demand'
+
+    payload = {
+        'tags': tags,
+        'job_type': f'hysds-io-{job_type}:{job_release}',
+        'hysds_io': f'hysds-io-{job_type}:{job_release}',
+        'queue': job_queue,
+        'priority': priority,
+        'query': json.dumps(query) if isinstance(query, (dict, list)) else query,
+        'kwargs': json.dumps(kwargs) if isinstance(kwargs, (dict, list)) else kwargs,
+        'enable_dedup': dedup,
+    }
+
+    payload.update(payload_kwargs)
+
+    logger.info(f'GRQ payload: {json.dumps(payload)}')
+    logger.info(f'Submitting on-demand job to {grq_url}')
+
+    resp = requests.post(grq_url, json=payload, headers={'Content-Type': 'application/json'}, verify=False)
+
+    logger.info(f"Request code: {resp.status_code}")
+    logger.info(f"Request text: {resp.text}")
+    resp.raise_for_status()
+
+    result = resp.json()
+
+    if "result" in result.keys() and "success" in result.keys():
+        if result["success"] is True:
+            job_id = result["result"]
+            logger.info(f"submitted job: {job_type} job_id: {job_id}")
+            return job_id
+        else:
+            logger.error(f"job not submitted successfully: {result}")
+            raise Exception(f"job not submitted successfully: {result}")
+    else:
+        raise Exception(f"job not submitted successfully: {result}")
+
+
+def lambda_handler(event, context):
+    logger.info(f"Got event: {json.dumps(event)}")
+
+    mozart_host = os.environ['MOZART_HOST']
+    job_release = os.environ['JOB_RELEASE']
+
+    es_query = event.pop('es_query')
+    job_type = event.pop('job_type')
+    job_queue = event.pop('job_queue')
+    priority = event.pop('priority')
+    tags = event.pop('tags')
+    kwargs = event.pop('kwargs')
+    dedup = event.pop('enable_dedup')
+
+    grq_on_demand(
+        mozart_host,
+        es_query,
+        job_type,
+        job_release,
+        job_queue,
+        priority,
+        tags,
+        kwargs,
+        dedup,
+        **event
+    )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('mozart_host', help='Mozart host (IP or hostname with optional port)')
+    parser.add_argument('es_query', help='Path to file with es query')
+    parser.add_argument('job_type', help='Type of job to submit')
+    parser.add_argument('job_release', help='Job release')
+    parser.add_argument('job_queue', help='Job queue')
+    parser.add_argument('priority', type=int, help='Job priority')
+    parser.add_argument('tags', help='Tags')
+    parser.add_argument('--dedup', action='store_true', help='Enable job dedupe')
+    parser.add_argument('--kwargs', required=False, help='Path to JSON file with job kwargs')
+
+    args = parser.parse_args()
+
+    with open(args.es_query) as fp:
+        es_query = json.load(fp)
+
+    if args.kwargs is not None:
+        with open(args.kwargs) as fp:
+            kwargs = json.load(fp)
+    else:
+        kwargs = {}
+
+    grq_on_demand(
+        args.mozart_host,
+        es_query,
+        args.job_type,
+        args.job_release,
+        args.job_queue,
+        args.priority,
+        args.tags,
+        kwargs,
+        args.dedup,
+    )

--- a/lambdas/grq-on-demand/requirements.txt
+++ b/lambdas/grq-on-demand/requirements.txt
@@ -1,0 +1,4 @@
+requests==2.32.4
+
+# urllib3 contains an incompatible change. pinning such that we stay on urllib3 1.x
+urllib3<2

--- a/lambdas/grq-on-demand/setup.py
+++ b/lambdas/grq-on-demand/setup.py
@@ -1,0 +1,207 @@
+"""
+Copyright (c) 2022 Jet Propulsion Laboratory,
+California Institute of Technology.  All rights reserved
+"""
+import glob
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+import setuptools
+import setuptools.command.sdist
+
+WHEELHOUSE = "wheelhouse"
+DIST = "dist"
+
+
+class Package(setuptools.Command):
+    """Package Code and Dependencies into wheelhouse"""
+    description = "Run wheels for dependencies and submodules dependencies"
+
+    ARCHIVE_NAME = "lambda-grq-on-demand-handler"
+
+    user_options = [
+        ('version=', 'v', 'version release'),
+        ('lambda-func=', 'l', 'Path to the Lambda function to softlink to '
+                              'lambda_function.py'),
+        ('workspace=', 'w', 'Workspace directory. '
+                            'Default is current working dir.'),
+        ('package-dir=', 'p', 'Directory where the lambda package will be '
+                              'located.')
+    ]
+
+    def __init__(self, dist):
+        self.dist = dist
+        setuptools.Command.__init__(self, dist)
+
+    def initialize_options(self):
+        self.version = None
+        self.lambda_func = None
+        self.workspace = None
+        self.package_dir = None
+
+    def finalize_options(self):
+        """Post-process options."""
+        if self.version is None:
+            raise Exception("Parameter --version is missing")
+        if self.lambda_func is None:
+            raise Exception("Parameter --lambda-func is missing")
+        if self.workspace is None:
+            self.workspace = os.getcwd()
+        self.workspace = os.path.abspath(self.workspace)
+        if self.package_dir is None:
+            raise Exception("Parameter --package-dir is missing")
+        else:
+            self.package_dir = os.path.abspath(self.package_dir)
+
+    def localize_requirements(self):
+        """
+        After the package is unpacked at the target destination, the
+        requirements can be installed locally from the wheelhouse folder using
+        the option --no-index on pip install which ignores package index
+        (only looking at --find-links URLs instead).
+        --find-links <url | path> looks for archive from url or path.
+        Since the original requirements.txt might have links to a non pip repo
+        such as github (https) it will parse the links for the archive from a
+        url and not from the wheelhouse. This functions creates a new
+        requirements.txt with the only name and version for each of the
+        packages, thus eliminating the need to fetch / parse links from http
+        sources and install all archives from the wheelhouse.
+        """
+        dependencies = open("requirements.txt").read().split("\n")
+        local_dependencies = []
+
+        for dependency in dependencies:
+            if dependency:
+                if "egg=" in dependency:
+                    pkg_name = dependency.split("egg=")[-1]
+                    local_dependencies.append(pkg_name)
+                elif "git+" in dependency:
+                    pkg_name = dependency.split("/")[-1].split(".")[0]
+                    local_dependencies.append(pkg_name)
+                else:
+                    local_dependencies.append(dependency)
+
+        print("local packages in wheel: %s", local_dependencies)
+        self.execute("mv requirements.txt requirements.orig")
+
+        with open("requirements.txt", "w") as requirements_file:
+            # filter is used to remove empty list members (None).
+            requirements_file.write("\n".join(
+                filter(None, local_dependencies)))
+
+    def execute(self, command, cwd=None):
+        """
+        The execute command will loop and keep on reading the stdout and check
+        for the return code and displays the output in real time.
+        """
+
+        print("Running shell command: ", command)
+
+        try:
+            return_code = subprocess.check_call(shlex.split(command),
+                                                stdout=sys.stdout,
+                                                stderr=sys.stderr, cwd=cwd)
+        except subprocess.CalledProcessError as e:
+            return_code = e.returncode
+            raise IOError("Shell commmand `%s` failed with return code %d." % (
+                    command, return_code)) from e
+
+        return return_code
+
+    def run_os_commands(self, commands, cwd=None):
+        for command in commands:
+            self.execute(command, cwd=cwd)
+
+    def restore_requirements_txt(self):
+        if os.path.exists("requirements.orig"):
+            print("Restoring original requirements.txt file")
+            commands = [
+                "rm requirements.txt",
+                "mv requirements.orig requirements.txt"
+            ]
+            self.run_os_commands(commands)
+
+    def __create_softlink(self, lambda_func):
+        """
+        Softlink the lambda to lambda_function.py
+
+        :param lambda_func: The path to the lambda function to softlink
+        :return:
+        """
+        dir = os.path.dirname(lambda_func)
+        aws_lambda_file_path = os.path.join(dir, 'lambda_function.py')
+
+        # Clear out the symbolic link if it exists
+        if os.path.exists(aws_lambda_file_path) or \
+                os.path.islink(aws_lambda_file_path):
+            print("Unlinking existing symbolic link: {}".format(
+                aws_lambda_file_path))
+            os.unlink(aws_lambda_file_path)
+
+        print("Softlinking {} to {}".format(lambda_func,
+                                            aws_lambda_file_path))
+        os.symlink(lambda_func, aws_lambda_file_path)
+
+    def run(self):
+        commands = []
+        commands.extend([
+            "rm -rf {workspace}/{dir}".format(workspace=self.workspace,
+                                              dir=WHEELHOUSE),
+            "rm -rf {workspace}/{dir}".format(workspace=self.workspace,
+                                              dir=DIST),
+            "mkdir -p {workspace}/{dir}".format(workspace=self.workspace,
+                                                dir=WHEELHOUSE),
+            "mkdir -p {workspace}/{dir}".format(workspace=self.workspace,
+                                                dir=DIST),
+            "pip wheel --wheel-dir={workspace}/{dir} "
+            "-r requirements.txt".format(workspace=self.workspace,
+                                         dir=WHEELHOUSE),
+            "unzip \"{workspace}/{dir}/*.whl\" -d {workspace}/{dir}".format(
+                workspace=self.workspace, dir=WHEELHOUSE),
+            "find {workspace}/{dir} -type f -name \"*.whl\" -delete".format(
+                workspace=self.workspace, dir=WHEELHOUSE)
+        ])
+
+        print("Packing requirements.txt into wheelhouse")
+        self.run_os_commands(commands)
+        print("Generating local requirements.txt")
+        self.localize_requirements()
+        self.__create_softlink(self.lambda_func)
+        print("Packing code and wheelhouse into dist")
+        lambda_package = "{}/{}/{}-{}.zip".format(self.workspace, DIST,
+                                                  self.ARCHIVE_NAME,
+                                                  self.version)
+        self.execute(
+            "zip -9 {package_name} {files}".format(
+                package_name=lambda_package,
+                files=' '.join(glob.glob("lambda_function.py"))))
+        os.chdir(os.path.join(self.workspace, WHEELHOUSE))
+        self.execute(
+            "zip -rg ../{dist}/{archive_name}-{version}.zip "
+            "{files}".format(dist=DIST, archive_name=self.ARCHIVE_NAME,
+                             version=self.version,
+                             files=' '.join(glob.glob("**", recursive=True))))
+        print("Copying {} to {}".format(os.path.abspath(lambda_package),
+                                        self.package_dir))
+        if not os.path.exists(self.package_dir):
+            os.mkdir(self.package_dir)
+        shutil.copyfile(os.path.abspath(lambda_package),
+                        os.path.join(self.package_dir,
+                                     os.path.basename(lambda_package)))
+        os.chdir("../..")
+        self.restore_requirements_txt()
+
+
+setuptools.setup(
+    name="lambda-grq-on-demand-handler",
+    author="PCM",
+    description="Lambda package for submitting arbitrary GRQ on-demand jobs",
+    packages=setuptools.find_packages(),
+    include_package_data=True,
+    cmdclass={
+        "package": Package
+    },
+)


### PR DESCRIPTION
This PR adds 2 new lambda functions.

Related PR: nasa/opera-sds-pcm#1415

## Catalog Ingest

This function submits a catalog ingest job via the Mozart jobs API. The job must have a end date and start date param, the values for which are calculated as the current event time and a fixed offset before, respectively.

### Configuration

Environment variables:
- MOZART_HOST: IP or hostname (with optional port) of Mozart
- JOB_RELEASE: Release of the jobs to be submitted, usually the PCM branch deployed
- START_PARAM: [OPTIONAL] Name of the HySDS parameter that takes the start date value (default: start_date)
- END_PARAM: [OPTIONAL] Name of the HySDS parameter that takes the end date value (default: end_date)
- START_PARAM_PREFIX: [OPTIONAL] Prefix to apply to the start date value (useful if the job expects something like --start=<date>)
- END_PARAM_PREFIX: [OPTIONAL] Prefix to apply to the end date value (useful if the job expects something like --end=<date>)

Lambda input:

```json
{
  "time": "base time (derived from source event): str",
  "job_type": "name of HySDS job to submit: str",
  "job_queue": "HySDS queue to submit job to: str",
  "priority": "job priority: int",
  "tags": "job tag: str",
  "minutes": "number of minutes to offset query start from wrt 'time': int, optional (default=60)",
  "revision_margin": "number of minutes to shift base time: int, optional(default=0)",
  "extra_params": "extra params to pass to HySDS job: object, optional (default={})",
  "enable_dedup": "enable deduping of submitted jobs: bool, optional (default=false)",
}
```

Example:

```json
{
    "time": "2026-05-28T18:10:41Z",
    "job_type": "gcov_catalog_ingest",
    "job_queue": "opera-job_worker-gcov_catalog_ingest",
    "priority": 0,
    "tags": "timer-GCOV-catalog-ingest",
    "minutes": 60,
    "revision_margin": 0,
    "enable_dedup": true
}
```

## GRQ on demand

This function submits a job on 0 or more GRQ dataset entries via the GRQ on-demand API.

### Configuration

Environment variables:
- MOZART_HOST: IP or hostname (with optional port) of Mozart
- JOB_RELEASE: Release of the jobs to be submitted, usually the PCM branch deployed

Lambda input:

```json
{
  "es_query": "elasticsearch query to use for job submissions: object or JSON-serialized object str",
  "job_type": "name of HySDS job to submit: str",
  "job_queue": "HySDS queue to submit jobs to: str",
  "priority": "job priority: int",
  "tags": "tag for submitted jobs: str",
  "kwargs": "additional args to pass to submitted jobs: object or JSON-serialized object str",
  "enable_dedup": "enable deduping of submitted jobs: bool, optional (default=false)",
}
```

Example:

```json
{
  "es_query": {
    "bool": {
      "must": [
        {
          "bool": {
            "must": [
              {
                "term": {
                  "dataset.keyword": "dswx_ni-state-config"
                }
              }
            ],
            "must_not": [
              {
                "term": {
                  "metadata.is_complete": true
                }
              },
              {
                "term": {
                  "metadata.is_expired": true
                }
              },
              {
                "term": {
                  "metadata.is_skipped": true
                }
              }
            ]
          }
        }
      ]
    }
  },
  "job_type": "dswx_ni_mgrs_evaluator",
  "job_queue": "opera-job_worker-evaluator",
  "priority": 0,
  "tags": "timer-dswx-ni-stateconfig-expiration-eval",
  "kwargs": {},
  "enable_dedup": false
}
```